### PR TITLE
comment out patch_thread

### DIFF
--- a/pychrome/__init__.py
+++ b/pychrome/__init__.py
@@ -3,8 +3,8 @@
 
 from __future__ import unicode_literals
 
-from pychrome.browser import *
-from pychrome.tab import *
-from pychrome.exceptions import *
+from .browser import *
+from .tab import *
+# from .exceptions import *
 
 __version__ = '0.2.0'

--- a/pychrome/browser.py
+++ b/pychrome/browser.py
@@ -8,7 +8,7 @@ gevent.monkey.patch_socket()
 
 import requests
 
-from pychrome.tab import Tab
+from .tab import Tab
 
 
 __all__ = ["Browser"]

--- a/pychrome/tab.py
+++ b/pychrome/tab.py
@@ -18,7 +18,7 @@ import gevent.event
 import gevent.queue
 import gevent.lock
 
-from pychrome.exceptions import *
+from .exceptions import *
 
 
 __all__ = ["Tab"]

--- a/pychrome/tab.py
+++ b/pychrome/tab.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 
 import gevent.monkey
 gevent.monkey.patch_socket()
-gevent.monkey.patch_thread()
+#  gevent.monkey.patch_thread()
 
 import os
 import json


### PR DESCRIPTION
I am opening an MongoDB client before importing pychrome.
```python
from pymongo import MongoClient
c = MongoClient("12.12.12.12", 12345)
import pychrome
```
The following error is observed
```
{'_MongoClient__options': <pymongo.client_options.ClientOptions object at 0x1019f51d0>, '_MongoClient__default_database_name': None, '_MongoClient__lock': <unlocked _thread.lock object at 0x101975f08>, '_MongoClient__cursor_manager': None, '_MongoClient__kill_cursors_queue': [], '_event_listeners': <pymongo.monitoring._EventListeners object at 0x1019f5b38>, '_MongoClient__index_cache': {}, '_MongoClient__index_cache_lock': <unlocked _thread.lock object at 0x101975e18>, '_BaseObject__codec_options': CodecOptions(document_class=dict, tz_aware=False, uuid_representation=PYTHON_LEGACY, unicode_decode_error_handler='strict', tzinfo=None), '_BaseObject__read_preference': Primary(), '_BaseObject__write_concern': WriteConcern(), '_BaseObject__read_concern': ReadConcern(), '_MongoClient__all_credentials': {}, '_topology_settings': <pymongo.settings.TopologySettings object at 0x10207ac50>, '_topology': <pymongo.topology.Topology object at 0x102247e80>, '_kill_cursors_executor': <pymongo.periodic_executor.PeriodicExecutor object at 0x10224c978>}
Traceback (most recent call last):
  File "<frozen importlib._bootstrap>", line 961, in _find_and_load
  File "<frozen importlib._bootstrap>", line 950, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 655, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 205, in _call_with_frames_removed
  File "/Users/jimmytran/.virtualenvs/crypto/lib/python3.6/site-packages/pychrome/browser.py", line 11, in <module>
    from pychrome.tab import Tab
  File "<frozen importlib._bootstrap>", line 961, in _find_and_load
  File "<frozen importlib._bootstrap>", line 154, in __exit__
  File "<frozen importlib._bootstrap>", line 106, in release
RuntimeError: cannot release un-acquired lock

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<frozen importlib._bootstrap>", line 961, in _find_and_load
  File "<frozen importlib._bootstrap>", line 950, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 655, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 205, in _call_with_frames_removed
  File "/Users/jimmytran/.virtualenvs/crypto/lib/python3.6/site-packages/pychrome/__init__.py", line 6, in <module>
    from pychrome.browser import Browser
  File "<frozen importlib._bootstrap>", line 961, in _find_and_load
  File "<frozen importlib._bootstrap>", line 154, in __exit__
  File "<frozen importlib._bootstrap>", line 106, in release
RuntimeError: cannot release un-acquired lock

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/jimmytran/Workspace/crypto/crypto/__main__.py", line 5, in <module>
    import pychrome
  File "<frozen importlib._bootstrap>", line 961, in _find_and_load
  File "<frozen importlib._bootstrap>", line 154, in __exit__
  File "<frozen importlib._bootstrap>", line 106, in release
RuntimeError: cannot release un-acquired lock
```

Removing `#gevent.monkey.patch_thread()` in `tab.py` solves the issue.
```python
import gevent.monkey
gevent.monkey.patch_socket()
# gevent.monkey.patch_thread()
```