### PR TITLE
Add chrome instance capabilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,7 @@ matrix:
 
 addons:
   chrome: stable
-before_install:
-  - # start your web application and listen on `localhost`
-  - google-chrome-stable --headless --no-sandbox --disable-gpu --remote-debugging-port=9222 http://localhost &
-
+  
 install:
   - pip install -r requirements_dev.txt
   - python setup.py install

--- a/pychrome/browser.py
+++ b/pychrome/browser.py
@@ -73,6 +73,13 @@ class Browser(object):
     def version(self, timeout=None):
         rp = requests.get("%s/json/version" % self.dev_url, json=True, timeout=timeout)
         return rp.json()
+    
+    def __enter__(self):
+        return self
+    
+    def __exit__(self, *args):
+        if self.service:
+            self.service.__exit__()
 
     def __str__(self):
         return '<Browser %s>' % self.dev_url

--- a/pychrome/browser.py
+++ b/pychrome/browser.py
@@ -7,6 +7,7 @@ import requests
 
 from .tab import Tab
 
+from .service import Service
 
 __all__ = ["Browser"]
 

--- a/pychrome/browser.py
+++ b/pychrome/browser.py
@@ -14,7 +14,14 @@ __all__ = ["Browser"]
 class Browser(object):
     _all_tabs = {}
 
-    def __init__(self, url="http://127.0.0.1:9222"):
+    def __init__(self, url=None, *args, **kwargs):
+        self.service = None
+        if not url:
+            # Start headless chrome service. For visible chrome, call
+            # with Browser(headless=False)
+            self.service = Service(*args, **kwargs)
+            url = self.service.url
+
         self.dev_url = url
 
         if self.dev_url not in self._all_tabs:

--- a/pychrome/service.py
+++ b/pychrome/service.py
@@ -5,13 +5,16 @@ import subprocess
 from subprocess import PIPE
 import time
 import socket
-from tempfile import TemporaryDirectory
 
 try:
     from shutil import which
 except ImportError:
     from distutils.spawn import find_executable as which
 
+try:
+    from tempfile import TemporaryDirectory
+except ImportError:
+    from .tempdir import TemporaryDirectory
 
 try:
     from subprocess import DEVNULL

--- a/pychrome/service.py
+++ b/pychrome/service.py
@@ -5,8 +5,12 @@ import subprocess
 from subprocess import PIPE
 import time
 import socket
-from shutil import which
 from tempfile import TemporaryDirectory
+
+try:
+    from shutil import which
+except ImportError:
+    from distutils.spawn import find_executable as which
 
 
 try:

--- a/pychrome/service.py
+++ b/pychrome/service.py
@@ -21,7 +21,9 @@ class Service(object):
     def __init__(self, executable = None, port=0, log_file=DEVNULL, env=None,
                  start_error_message="", service_args = None, headless = True):
         if not executable:
-            executable = which("chrome")
+            for chrome_exe in ["chrome", "google-chrome-stable"]
+                executable = which(chrome_exe)
+                if executable: break
             if not executable:
                 raise ChromeException("Could not find chrome executable in system path!")
         

--- a/pychrome/service.py
+++ b/pychrome/service.py
@@ -21,7 +21,7 @@ class Service(object):
     def __init__(self, executable = None, port=0, log_file=DEVNULL, env=None,
                  start_error_message="", service_args = None, headless = True):
         if not executable:
-            for chrome_exe in ["chrome", "google-chrome-stable"]
+            for chrome_exe in ["chrome", "google-chrome-stable"]:
                 executable = which(chrome_exe)
                 if executable: break
             if not executable:

--- a/pychrome/service.py
+++ b/pychrome/service.py
@@ -1,0 +1,236 @@
+import errno
+import os
+import platform
+import subprocess
+from subprocess import PIPE
+import time
+import socket
+from shutil import which
+from tempfile import TemporaryDirectory
+
+
+try:
+    from subprocess import DEVNULL
+    _HAS_NATIVE_DEVNULL = True
+except ImportError:
+    DEVNULL = -3
+    _HAS_NATIVE_DEVNULL = False
+
+class Service(object):
+
+    def __init__(self, executable = None, port=0, log_file=DEVNULL, env=None,
+                 start_error_message="", service_args = None, headless = True):
+        if not executable:
+            executable = which("chrome")
+            if not executable:
+                raise ChromeException("Could not find chrome executable in system path!")
+        
+        self.path = executable
+        
+        self.tmpdir = TemporaryDirectory()
+        
+        self.port = port
+        if self.port == 0:
+            self.port = free_port()
+        
+        self.service_args = service_args or []
+        self.service_args += ['--disable-background-networking',
+                              '--disable-client-side-phishing-detection',
+                              '--disable-default-apps', '--disable-hang-monitor',
+                              '--disable-infobars', '--disable-popup-blocking',
+                              '--disable-prompt-on-repost', '--disable-sync',
+                              '--disable-web-resources', '--enable-automation',
+                              '--enable-logging', '--password-store=basic',
+                              '--force-fieldtrials=SiteIsolationExtensions/Control',
+                              '--ignore-certificate-errors', '--log-level=0',
+                              '--metrics-recording-only', '--no-first-run',
+                              '--test-type=browser', '--use-mock-keychain']
+        self.service_args += ['--user-data-dir='  + self.tmpdir.name]
+        self.service_args += ['--remote-debugging-port=' + str(self.port)]
+        self.service_args += ['--headless'] if headless else []
+
+        if not _HAS_NATIVE_DEVNULL and log_file == DEVNULL:
+            log_file = open(os.devnull, 'wb')
+
+        self.start_error_message = start_error_message
+        self.log_file = log_file
+        self.env = env or os.environ
+        
+        self.tmpdir = TemporaryDirectory()
+        
+        self.start()
+
+    @property
+    def url(self):
+        """
+        Gets the url of the Service
+        """
+        return "http://%s" % join_host_port('127.0.0.1', self.port)
+
+    def start(self):
+        """
+        Starts the Service.
+
+        :Exceptions:
+         - ChromeException : Raised either when it can't start the service
+           or when it can't connect to the service
+        """
+        try:
+            cmd = [self.path]
+            cmd.extend(self.service_args)
+            self.process = subprocess.Popen(cmd, env=self.env,
+                                            close_fds=platform.system() != 'Windows',
+                                            stdout=self.log_file,
+                                            stderr=self.log_file,
+                                            stdin=PIPE)
+        except TypeError:
+            raise
+        except OSError as err:
+            if err.errno == errno.ENOENT:
+                raise ChromeException(
+                    "'%s' executable needs to be in PATH. %s" % (
+                        os.path.basename(self.path), self.start_error_message)
+                )
+            elif err.errno == errno.EACCES:
+                raise ChromeException(
+                    "'%s' executable may have wrong permissions. %s" % (
+                        os.path.basename(self.path), self.start_error_message)
+                )
+            else:
+                raise
+        except Exception as e:
+            raise ChromeException(
+                "The executable %s needs to be available in the path. %s\n%s" %
+                (os.path.basename(self.path), self.start_error_message, str(e)))
+        count = 0
+        while True:
+            self.assert_process_still_running()
+            if self.is_connectable():
+                break
+            count += 1
+            time.sleep(1)
+            if count == 30:
+                raise ChromeException("Can not connect to the Service %s" % self.path)
+
+    def assert_process_still_running(self):
+        return_code = self.process.poll()
+        if return_code is not None:
+            raise ChromeException(
+                'Service %s unexpectedly exited. Status code was: %s'
+                % (self.path, return_code)
+            )
+
+    def is_connectable(self):
+        return is_connectable(self.port)
+
+    def stop(self):
+        """
+        Stops the service.
+        """
+        if self.log_file != PIPE and not (self.log_file == DEVNULL and _HAS_NATIVE_DEVNULL):
+            try:
+                self.log_file.close()
+            except Exception:
+                pass
+
+        if self.process is None:
+            return
+
+        try:
+            if self.process:
+                for stream in [self.process.stdin,
+                               self.process.stdout,
+                               self.process.stderr]:
+                    try:
+                        stream.close()
+                    except AttributeError:
+                        pass
+                self.process.terminate()
+                self.process.wait()
+                self.process.kill()
+                self.process = None
+        except OSError:
+            pass
+        
+    def __enter__(self):
+        return self
+    
+    def __exit__(self, *args):
+        self.__del__()
+
+    def __del__(self):
+        # `subprocess.Popen` doesn't send signal on `__del__`;
+        # so we attempt to close the launched process when `__del__`
+        # is triggered.
+        try:
+            self.stop()
+        except Exception:
+            pass
+        
+        try:
+            self.tmpdir.cleanup()
+        except Exception:
+            pass
+
+
+class ChromeException(Exception):
+    """
+    Base webdriver exception.
+    """
+
+    def __init__(self, msg=None, screen=None, stacktrace=None):
+        self.msg = msg
+        self.screen = screen
+        self.stacktrace = stacktrace
+
+    def __str__(self):
+        exception_msg = "Message: %s\n" % self.msg
+        if self.screen is not None:
+            exception_msg += "Screenshot: available via screen\n"
+        if self.stacktrace is not None:
+            stacktrace = "\n".join(self.stacktrace)
+            exception_msg += "Stacktrace:\n%s" % stacktrace
+        return exception_msg
+
+
+def free_port():
+    """
+    Determines a free port using sockets.
+    """
+    free_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    free_socket.bind(('0.0.0.0', 0))
+    free_socket.listen(5)
+    port = free_socket.getsockname()[1]
+    free_socket.close()
+    return port
+
+
+def is_connectable(port, host="localhost"):
+    """
+    Tries to connect to the server at port to see if it is running.
+    :Args:
+     - port - The port to connect.
+    """
+    socket_ = None
+    try:
+        socket_ = socket.create_connection((host, port), 1)
+        result = True
+    except socket.error:
+        result = False
+    finally:
+        if socket_:
+            socket_.close()
+    return result
+
+
+def join_host_port(host, port):
+    """Joins a hostname and port together.
+    This is a minimal implementation intended to cope with IPv6 literals. For
+    example, _join_host_port('::1', 80) == '[::1]:80'.
+    :Args:
+        - host - A hostname.
+        - port - An integer port.
+    """
+    if ':' in host and not host.startswith('['):
+        return '[%s]:%d' % (host, port)
+    return '%s:%d' % (host, port)

--- a/pychrome/tempdir.py
+++ b/pychrome/tempdir.py
@@ -1,0 +1,87 @@
+from __future__ import print_function
+
+import warnings as _warnings
+import os as _os
+
+from tempfile import mkdtemp
+
+class TemporaryDirectory(object):
+    """Create and return a temporary directory.  This has the same
+    behavior as mkdtemp but can be used as a context manager.  For
+    example:
+
+        with TemporaryDirectory() as tmpdir:
+            ...
+
+    Upon exiting the context, the directory and everything contained
+    in it are removed.
+    """
+
+    def __init__(self, suffix="", prefix="tmp", dir=None):
+        self._closed = False
+        self.name = None # Handle mkdtemp raising an exception
+        self.name = mkdtemp(suffix, prefix, dir)
+
+    def __repr__(self):
+        return "<{} {!r}>".format(self.__class__.__name__, self.name)
+
+    def __enter__(self):
+        return self.name
+
+    def cleanup(self, _warn=False):
+        if self.name and not self._closed:
+            try:
+                self._rmtree(self.name)
+            except (TypeError, AttributeError) as ex:
+                # Issue #10188: Emit a warning on stderr
+                # if the directory could not be cleaned
+                # up due to missing globals
+                if "None" not in str(ex):
+                    raise
+                print("ERROR: {!r} while cleaning up {!r}".format(ex, self,),
+                      file=_sys.stderr)
+                return
+            self._closed = True
+            if _warn:
+                self._warn("Implicitly cleaning up {!r}".format(self),
+                           ResourceWarning)
+
+    def __exit__(self, exc, value, tb):
+        self.cleanup()
+
+    def __del__(self):
+        # Issue a ResourceWarning if implicit cleanup needed
+        self.cleanup(_warn=True)
+
+    # XXX (ncoghlan): The following code attempts to make
+    # this class tolerant of the module nulling out process
+    # that happens during CPython interpreter shutdown
+    # Alas, it doesn't actually manage it. See issue #10188
+    _listdir = staticmethod(_os.listdir)
+    _path_join = staticmethod(_os.path.join)
+    _isdir = staticmethod(_os.path.isdir)
+    _islink = staticmethod(_os.path.islink)
+    _remove = staticmethod(_os.remove)
+    _rmdir = staticmethod(_os.rmdir)
+    _warn = _warnings.warn
+
+    def _rmtree(self, path):
+        # Essentially a stripped down version of shutil.rmtree.  We can't
+        # use globals because they may be None'ed out at shutdown.
+        for name in self._listdir(path):
+            fullname = self._path_join(path, name)
+            try:
+                isdir = self._isdir(fullname) and not self._islink(fullname)
+            except OSError:
+                isdir = False
+            if isdir:
+                self._rmtree(fullname)
+            else:
+                try:
+                    self._remove(fullname)
+                except OSError:
+                    pass
+        try:
+            self._rmdir(path)
+        except OSError:
+            pass

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3,11 +3,28 @@
 import time
 import logging
 import pychrome
-
+import os
+import pytest
 
 logging.basicConfig(level=logging.INFO)
-
-
+   
+@pytest.fixture(scope='session')  # one server to rule'em all
+def browser():  
+    # A bug in Travis-CI's testing environment requires that chrome requires
+    # sudo access to set up the sandbox. Hence we turn it off.
+    # A regular environment  does not need these service args
+    service_args = ['--no-sandbox', '--disable-gpu']
+    
+    with pychrome.Browser(service_args=service_args) as browser:
+        yield browser
+        
+@pytest.fixture(autouse=True)
+def run_around_tests(browser):
+    # Code that will run before each test:
+    close_all_tabs(browser)
+    # Run test
+    yield
+	
 def close_all_tabs(browser):
     if len(browser.list_tab()) == 0:
         return
@@ -17,39 +34,25 @@ def close_all_tabs(browser):
 
     time.sleep(1)
     assert len(browser.list_tab()) == 0
-
-
-def setup_function(function):
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
-    close_all_tabs(browser)
-
-
-def teardown_function(function):
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
-    close_all_tabs(browser)
-
-
-def test_chome_version():
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
+    
+    
+def test_chome_version(browser):
     browser_version = browser.version()
     assert isinstance(browser_version, dict)
 
 
-def test_browser_list():
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
+def test_browser_list(browser):
     tabs = browser.list_tab()
     assert len(tabs) == 0
 
 
-def test_browser_new():
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
+def test_browser_new(browser):
     browser.new_tab()
     tabs = browser.list_tab()
     assert len(tabs) == 1
 
 
-def test_browser_activate_tab():
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
+def test_browser_activate_tab(browser):
     tabs = []
     for i in range(10):
         tabs.append(browser.new_tab())
@@ -58,9 +61,7 @@ def test_browser_activate_tab():
         browser.activate_tab(tab)
 
 
-def test_browser_tabs_map():
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
-
+def test_browser_tabs_map(browser):
     tab = browser.new_tab()
     assert tab in browser.list_tab()
     assert tab in browser.list_tab()
@@ -69,8 +70,7 @@ def test_browser_tabs_map():
     assert tab not in browser.list_tab()
 
 
-def test_browser_new_10_tabs():
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
+def test_browser_new_10_tabs(browser):
     tabs = []
     for i in range(10):
         tabs.append(browser.new_tab())
@@ -85,8 +85,7 @@ def test_browser_new_10_tabs():
     assert len(browser.list_tab()) == 0
 
 
-def test_browser_new_100_tabs():
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
+def test_browser_new_100_tabs(browser):
     tabs = []
     for i in range(100):
         tabs.append(browser.new_tab())

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -20,36 +20,36 @@ def close_all_tabs(browser):
 
 
 def setup_function(function):
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
     close_all_tabs(browser)
 
 
 def teardown_function(function):
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
     close_all_tabs(browser)
 
 
 def test_chome_version():
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
     browser_version = browser.version()
     assert isinstance(browser_version, dict)
 
 
 def test_browser_list():
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
     tabs = browser.list_tab()
     assert len(tabs) == 0
 
 
 def test_browser_new():
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
     browser.new_tab()
     tabs = browser.list_tab()
     assert len(tabs) == 1
 
 
 def test_browser_activate_tab():
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
     tabs = []
     for i in range(10):
         tabs.append(browser.new_tab())
@@ -59,7 +59,7 @@ def test_browser_activate_tab():
 
 
 def test_browser_tabs_map():
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
 
     tab = browser.new_tab()
     assert tab in browser.list_tab()
@@ -70,7 +70,7 @@ def test_browser_tabs_map():
 
 
 def test_browser_new_10_tabs():
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
     tabs = []
     for i in range(10):
         tabs.append(browser.new_tab())
@@ -86,7 +86,7 @@ def test_browser_new_10_tabs():
 
 
 def test_browser_new_100_tabs():
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
     tabs = []
     for i in range(100):
         tabs.append(browser.new_tab())

--- a/tests/test_multi_tabs.py
+++ b/tests/test_multi_tabs.py
@@ -23,12 +23,12 @@ def close_all_tabs(browser):
 
 
 def setup_function(function):
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
     close_all_tabs(browser)
 
 
 def teardown_function(function):
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
     close_all_tabs(browser)
 
 
@@ -41,7 +41,7 @@ def new_multi_tabs(browser, n):
 
 
 def test_normal_callmethod():
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
     tabs = new_multi_tabs(browser, 10)
 
     for tab in tabs:
@@ -59,7 +59,7 @@ def test_normal_callmethod():
 
 
 def test_set_event_listener():
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
     tabs = new_multi_tabs(browser, 10)
 
     def request_will_be_sent(tab, **kwargs):

--- a/tests/test_multi_tabs.py
+++ b/tests/test_multi_tabs.py
@@ -4,17 +4,33 @@ import time
 import logging
 import pychrome
 import functools
+import pytest
 
 
 logging.basicConfig(level=logging.INFO)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
 
-
+@pytest.fixture(scope='session')  # one server to rule'em all
+def browser():  
+    # A bug in Travis-CI's testing environment requires that chrome requires
+    # sudo access to set up the sandbox. Hence we turn it off.
+    # A regular environment  does not need these service args
+    service_args = ['--no-sandbox', '--disable-gpu']
+    
+    with pychrome.Browser(service_args=service_args) as browser:
+        yield browser
+        
+@pytest.fixture(autouse=True)
+def run_around_tests(browser):
+    # Code that will run before each test:
+    close_all_tabs(browser)
+    # Run test
+    yield
+	
 def close_all_tabs(browser):
     if len(browser.list_tab()) == 0:
         return
 
-    logging.debug("[*] recycle")
     for tab in browser.list_tab():
         browser.close_tab(tab)
 
@@ -22,26 +38,15 @@ def close_all_tabs(browser):
     assert len(browser.list_tab()) == 0
 
 
-def setup_function(function):
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
-    close_all_tabs(browser)
-
-
-def teardown_function(function):
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
-    close_all_tabs(browser)
-
-
-def new_multi_tabs(browser, n):
+def new_multi_tabs(b, n):
     tabs = []
     for i in range(n):
-        tabs.append(browser.new_tab())
+        tabs.append(b.new_tab())
 
     return tabs
 
 
-def test_normal_callmethod():
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
+def test_normal_callmethod(browser):
     tabs = new_multi_tabs(browser, 10)
 
     for tab in tabs:
@@ -58,8 +63,7 @@ def test_normal_callmethod():
         tab.stop()
 
 
-def test_set_event_listener():
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
+def test_set_event_listener(browser):
     tabs = new_multi_tabs(browser, 10)
 
     def request_will_be_sent(tab, **kwargs):

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+import time
+import logging
+import pychrome
+import os
+import pytest
+
+logging.basicConfig(level=logging.INFO)
+   
+    
+def test_wrong_executable():
+    with pytest.raises(pychrome.service.ChromeException) as e_info:
+        with pychrome.Browser(executable="something_nonexistant") as browser:
+            assert False, "Never get here"        
+
+def test_killed_process():
+    with pytest.raises(pychrome.service.ChromeException) as e_info:
+        with pychrome.Browser(executable="something_nonexistant") as browser:
+            browser.service.process.kill()
+            tab = browser.new_tab()
+            assert False, "Never get here"
+        
+def test_lost_connection():
+    with pytest.raises(pychrome.service.ChromeException) as e_info:
+        with pychrome.Browser(executable="something_nonexistant") as browser:
+            browser.service.port += 1
+            tab = browser.new_tab()
+            assert False, "Never get here"

--- a/tests/test_single_tab.py
+++ b/tests/test_single_tab.py
@@ -20,17 +20,17 @@ def close_all_tabs(browser):
 
 
 def setup_function(function):
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
     close_all_tabs(browser)
 
 
 def teardown_function(function):
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
     close_all_tabs(browser)
 
 
 def test_normal_callmethod():
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
     tab = browser.new_tab()
 
     tab.start()
@@ -46,7 +46,7 @@ def test_normal_callmethod():
 
 
 def test_invalid_method():
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
     tab = browser.new_tab()
 
     tab.start()
@@ -59,7 +59,7 @@ def test_invalid_method():
 
 
 def test_invalid_params():
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
     tab = browser.new_tab()
 
     tab.start()
@@ -90,7 +90,7 @@ def test_invalid_params():
 
 
 def test_set_event_listener():
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
     tab = browser.new_tab()
 
     def request_will_be_sent(**kwargs):
@@ -110,7 +110,7 @@ def test_set_event_listener():
 
 
 def test_set_wrong_listener():
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
     tab = browser.new_tab()
 
     tab.start()
@@ -123,7 +123,7 @@ def test_set_wrong_listener():
 
 
 def test_get_event_listener():
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
     tab = browser.new_tab()
 
     def request_will_be_sent(**kwargs):
@@ -151,7 +151,7 @@ def test_get_event_listener():
 
 
 def test_reuse_tab_error():
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
     tab = browser.new_tab()
 
     def request_will_be_sent(**kwargs):
@@ -177,7 +177,7 @@ def test_reuse_tab_error():
 
 
 def test_del_event_listener():
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
     tab = browser.new_tab()
     test_list = []
 
@@ -199,7 +199,7 @@ def test_del_event_listener():
 
 
 def test_del_all_event_listener():
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
     tab = browser.new_tab()
     test_list = []
 
@@ -228,7 +228,7 @@ class CallableClass(object):
 
 
 def test_use_callable_class_event_listener():
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
     tab = browser.new_tab()
 
     tab.start()
@@ -246,7 +246,7 @@ def test_use_callable_class_event_listener():
 
 
 def test_status():
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
     tab = browser.new_tab()
 
     assert tab.status == pychrome.Tab.status_initial
@@ -275,7 +275,7 @@ def test_status():
 
 
 def test_call_method_timeout():
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
     tab = browser.new_tab()
 
     tab.start()
@@ -295,7 +295,7 @@ def test_call_method_timeout():
 
 
 def test_callback_exception():
-    browser = pychrome.Browser()
+    browser = pychrome.Browser(url="http://127.0.0.1:9222")
     tab = browser.new_tab()
 
     def request_will_be_sent(**kwargs):

--- a/tests/test_single_tab.py
+++ b/tests/test_single_tab.py
@@ -3,34 +3,39 @@
 import time
 import logging
 import pychrome
+import pytest
 
 logging.basicConfig(level=logging.INFO)
 
 
+@pytest.fixture(scope='session')  # one server to rule'em all
+def browser():  
+    # A bug in Travis-CI's testing environment requires that chrome requires
+    # sudo access to set up the sandbox. Hence we turn it off.
+    # A regular environment  does not need these service args
+    service_args = ['--no-sandbox', '--disable-gpu']
+    
+    with pychrome.Browser(service_args=service_args) as browser:
+        yield browser
+        
+@pytest.fixture(autouse=True)
+def run_around_tests(browser):
+    # Code that will run before each test:
+    close_all_tabs(browser)
+    # Run test
+    yield
+	
 def close_all_tabs(browser):
     if len(browser.list_tab()) == 0:
         return
 
-    logging.debug("[*] recycle")
     for tab in browser.list_tab():
         browser.close_tab(tab)
 
     time.sleep(1)
     assert len(browser.list_tab()) == 0
 
-
-def setup_function(function):
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
-    close_all_tabs(browser)
-
-
-def teardown_function(function):
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
-    close_all_tabs(browser)
-
-
-def test_normal_callmethod():
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
+def test_normal_callmethod(browser):
     tab = browser.new_tab()
 
     tab.start()
@@ -45,8 +50,7 @@ def test_normal_callmethod():
     tab.stop()
 
 
-def test_invalid_method():
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
+def test_invalid_method(browser):
     tab = browser.new_tab()
 
     tab.start()
@@ -58,8 +62,7 @@ def test_invalid_method():
     tab.stop()
 
 
-def test_invalid_params():
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
+def test_invalid_params(browser):
     tab = browser.new_tab()
 
     tab.start()
@@ -89,8 +92,7 @@ def test_invalid_params():
     tab.stop()
 
 
-def test_set_event_listener():
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
+def test_set_event_listener(browser):
     tab = browser.new_tab()
 
     def request_will_be_sent(**kwargs):
@@ -109,8 +111,7 @@ def test_set_event_listener():
         assert False, "never get here"
 
 
-def test_set_wrong_listener():
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
+def test_set_wrong_listener(browser):
     tab = browser.new_tab()
 
     tab.start()
@@ -122,8 +123,7 @@ def test_set_wrong_listener():
     tab.stop()
 
 
-def test_get_event_listener():
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
+def test_get_event_listener(browser):
     tab = browser.new_tab()
 
     def request_will_be_sent(**kwargs):
@@ -150,8 +150,7 @@ def test_get_event_listener():
     tab.stop()
 
 
-def test_reuse_tab_error():
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
+def test_reuse_tab_error(browser):
     tab = browser.new_tab()
 
     def request_will_be_sent(**kwargs):
@@ -176,8 +175,7 @@ def test_reuse_tab_error():
     tab.stop()
 
 
-def test_del_event_listener():
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
+def test_del_event_listener(browser):
     tab = browser.new_tab()
     test_list = []
 
@@ -198,8 +196,7 @@ def test_del_event_listener():
     tab.stop()
 
 
-def test_del_all_event_listener():
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
+def test_del_all_event_listener(browser):
     tab = browser.new_tab()
     test_list = []
 
@@ -227,8 +224,7 @@ class CallableClass(object):
         self.tab.stop()
 
 
-def test_use_callable_class_event_listener():
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
+def test_use_callable_class_event_listener(browser):
     tab = browser.new_tab()
 
     tab.start()
@@ -245,8 +241,7 @@ def test_use_callable_class_event_listener():
     tab.stop()
 
 
-def test_status():
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
+def test_status(browser):
     tab = browser.new_tab()
 
     assert tab.status == pychrome.Tab.status_initial
@@ -274,8 +269,7 @@ def test_status():
     assert tab.status == pychrome.Tab.status_stopped
 
 
-def test_call_method_timeout():
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
+def test_call_method_timeout(browser):
     tab = browser.new_tab()
 
     tab.start()
@@ -294,8 +288,7 @@ def test_call_method_timeout():
     tab.stop()
 
 
-def test_callback_exception():
-    browser = pychrome.Browser(url="http://127.0.0.1:9222")
+def test_callback_exception(browser):
     tab = browser.new_tab()
 
     def request_will_be_sent(**kwargs):


### PR DESCRIPTION
I propose a new version in which PyChrome automatically initiates a chrome service if no url was given to the Browser class. This takes the effort away from the end user to manually start or write code to start Chrome.

By default, a headless chrome instance will be started. At every start, a new chrome user is created in order to start with a clean slate and make testing reproducible as cookies are not stored permanently.

I have added context managers that gracefully cleans up the chrome service if the Browser instance is removed. It is also possible to start a Browser using a `with` statement.