### PR TITLE
Changed GET to PUT for new_tab

### DIFF
--- a/pychrome/browser.py
+++ b/pychrome/browser.py
@@ -24,7 +24,7 @@ class Browser(object):
 
     def new_tab(self, url=None, timeout=None):
         url = url or ''
-        rp = requests.get("%s/json/new?%s" % (self.dev_url, url), json=True, timeout=timeout)
+        rp = requests.put("%s/json/new?%s" % (self.dev_url, url), json=True, timeout=timeout)
         tab = Tab(**rp.json())
         self._tabs[tab.id] = tab
         return tab

--- a/pychrome/tab.py
+++ b/pychrome/tab.py
@@ -205,7 +205,7 @@ class Tab(object):
         self._started = True
         self.status = self.status_started
         self._stopped.clear()
-        self._ws = websocket.create_connection(self._websocket_url, enable_multithread=True)
+        self._ws = websocket.create_connection(self._websocket_url, enable_multithread=True, suppress_origin=True)
         self._recv_th.start()
         self._handle_event_th.start()
         return True


### PR DESCRIPTION
With Chrome 111 the new tab request should be changed to PUT call instead of get call