### PR TITLE
Fixed tests, examples, and tab.py

### DIFF
--- a/examples/multi_tabs_navigate.py
+++ b/examples/multi_tabs_navigate.py
@@ -49,10 +49,10 @@ class EventHandler(object):
 
 
 def close_all_tabs(browser):
-    if len(browser.list_tab()) == 0:
+    if len(browser.list_tab()) <= 1:
         return
 
-    for tab in browser.list_tab():
+    for tab in browser.list_tab()[1:]:
         try:
             tab.stop()
         except pychrome.RuntimeException:
@@ -61,7 +61,7 @@ def close_all_tabs(browser):
         browser.close_tab(tab)
 
     time.sleep(1)
-    assert len(browser.list_tab()) == 0
+    assert len(browser.list_tab()) == 1
 
 
 def main():
@@ -82,7 +82,7 @@ def main():
         tab.start()
         tab.Page.stopLoading()
         tab.Page.enable()
-        tab.Network.setRequestInterceptionEnabled(enabled=True)
+        tab.Network.setRequestInterception(patterns=[{ 'urlPattern': '*' }])
         tab.Page.navigate(url="http://httpbin.org/post")
 
     for tab in tabs:

--- a/examples/multi_tabs_pdf.py
+++ b/examples/multi_tabs_pdf.py
@@ -46,10 +46,10 @@ class EventHandler(object):
 
 
 def close_all_tabs(browser):
-    if len(browser.list_tab()) == 0:
+    if len(browser.list_tab()) <= 1:
         return
 
-    for tab in browser.list_tab():
+    for tab in browser.list_tab()[1:]:
         try:
             tab.stop()
         except pychrome.RuntimeException:

--- a/examples/multi_tabs_screenshot.py
+++ b/examples/multi_tabs_screenshot.py
@@ -44,10 +44,10 @@ class EventHandler(object):
 
 
 def close_all_tabs(browser):
-    if len(browser.list_tab()) == 0:
+    if len(browser.list_tab()) <= 1:
         return
 
-    for tab in browser.list_tab():
+    for tab in browser.list_tab()[1:]:
         try:
             tab.stop()
         except pychrome.RuntimeException:
@@ -56,7 +56,7 @@ def close_all_tabs(browser):
         browser.close_tab(tab)
 
     time.sleep(1)
-    assert len(browser.list_tab()) == 0
+    assert len(browser.list_tab()) == 1
 
 
 def main():

--- a/examples/post_request.py
+++ b/examples/post_request.py
@@ -15,6 +15,7 @@ class ChromiumClient(object):
 
         event_handler = EventHandler()
 
+        event_handler.set_tab(self.tab)
         event_handler.set_token('asdkflj497564dsklf')
         event_handler.set_post_data({
             'param1': 'value1',
@@ -22,11 +23,9 @@ class ChromiumClient(object):
         })
 
         url_pattern_object = {'urlPattern': '*fate0*'}
-        self.tab.Network.setRequestInterception(patterns=[url_pattern_object])
-
-        self.tab.Network.requestIntercepted = event_handler.on_request_intercepted
-
         self.tab.start()
+        self.tab.Network.requestIntercepted = event_handler.on_request_intercepted
+        self.tab.Network.setRequestInterception(patterns=[url_pattern_object])
 
         self.tab.Network.enable()
         self.tab.Page.enable()
@@ -43,7 +42,7 @@ class EventHandler(object):
     def __init__(self):
         self.tab = None
         self.token = None
-        self.is_first_request = False
+        self.is_first_request = True
         self.post_data = {}
 
     def set_tab(self, t):
@@ -75,7 +74,7 @@ class EventHandler(object):
                 'url': request['url'],
                 'method': 'POST',
                 'headers': request['headers'],
-                'postData': urllib.urlencode(self.post_data)
+                'postData': urllib.parse.urlencode(self.post_data)
             })
 
         self.tab.Network.continueInterceptedRequest(**new_args)

--- a/pychrome/tab.py
+++ b/pychrome/tab.py
@@ -119,9 +119,14 @@ class Tab(object):
             try:
                 self._ws.settimeout(1)
                 message_json = self._ws.recv()
+                if message_json == '':
+                    continue
                 message = json.loads(message_json)
             except websocket.WebSocketTimeoutException:
                 continue
+            except json.decoder.JSONDecodeError:  # '' and another
+                logger.error("invalid json", exc_info=True)
+                return
             except (websocket.WebSocketException, OSError):
                 if not self._stopped.is_set():
                     logger.error("websocket exception", exc_info=True)

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -9,14 +9,14 @@ logging.basicConfig(level=logging.INFO)
 
 
 def close_all_tabs(browser):
-    if len(browser.list_tab()) == 0:
+    if len(browser.list_tab()) <= 1:
         return
 
-    for tab in browser.list_tab():
+    for tab in browser.list_tab()[1:]:
         browser.close_tab(tab)
 
     time.sleep(1)
-    assert len(browser.list_tab()) == 0
+    assert len(browser.list_tab()) == 1
 
 
 def setup_function(function):
@@ -38,14 +38,14 @@ def test_chome_version():
 def test_browser_list():
     browser = pychrome.Browser()
     tabs = browser.list_tab()
-    assert len(tabs) == 0
+    assert len(tabs) == 1
 
 
 def test_browser_new():
     browser = pychrome.Browser()
     browser.new_tab()
     tabs = browser.list_tab()
-    assert len(tabs) == 1
+    assert len(tabs) == 1 + 1
 
 
 def test_browser_activate_tab():
@@ -62,10 +62,12 @@ def test_browser_tabs_map():
     browser = pychrome.Browser()
 
     tab = browser.new_tab()
+    time.sleep(0.5)
     assert tab in browser.list_tab()
     assert tab in browser.list_tab()
 
     browser.close_tab(tab)
+    time.sleep(0.5)
     assert tab not in browser.list_tab()
 
 
@@ -76,13 +78,13 @@ def test_browser_new_10_tabs():
         tabs.append(browser.new_tab())
 
     time.sleep(1)
-    assert len(browser.list_tab()) == 10
+    assert len(browser.list_tab()) == 10 + 1
 
     for tab in tabs:
         browser.close_tab(tab.id)
 
     time.sleep(1)
-    assert len(browser.list_tab()) == 0
+    assert len(browser.list_tab()) == 1
 
 
 def test_browser_new_100_tabs():
@@ -92,10 +94,10 @@ def test_browser_new_100_tabs():
         tabs.append(browser.new_tab())
 
     time.sleep(1)
-    assert len(browser.list_tab()) == 100
+    assert len(browser.list_tab()) == 100 + 1
 
     for tab in tabs:
         browser.close_tab(tab)
 
     time.sleep(1)
-    assert len(browser.list_tab()) == 0
+    assert len(browser.list_tab()) == 1

--- a/tests/test_multi_tabs.py
+++ b/tests/test_multi_tabs.py
@@ -11,15 +11,15 @@ logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 
 def close_all_tabs(browser):
-    if len(browser.list_tab()) == 0:
+    if len(browser.list_tab()) <= 1:
         return
 
     logging.debug("[*] recycle")
-    for tab in browser.list_tab():
+    for tab in browser.list_tab()[1:]:
         browser.close_tab(tab)
 
     time.sleep(1)
-    assert len(browser.list_tab()) == 0
+    assert len(browser.list_tab()) == 1
 
 
 def setup_function(function):
@@ -46,7 +46,7 @@ def test_normal_callmethod():
 
     for tab in tabs:
         tab.start()
-        result = tab.Page.navigate(url="http://www.fatezero.org")
+        result = tab.Page.navigate(url="https://github.com/fate0")
         assert result['frameId']
 
     time.sleep(3)
@@ -54,7 +54,7 @@ def test_normal_callmethod():
     for tab in tabs:
         result = tab.Runtime.evaluate(expression="document.domain")
         assert result['result']['type'] == 'string'
-        assert result['result']['value'] == 'www.fatezero.org'
+        assert result['result']['value'] == 'github.com'
         tab.stop()
 
 

--- a/tests/test_single_tab.py
+++ b/tests/test_single_tab.py
@@ -8,15 +8,15 @@ logging.basicConfig(level=logging.INFO)
 
 
 def close_all_tabs(browser):
-    if len(browser.list_tab()) == 0:
+    if len(browser.list_tab()) <= 1:
         return
 
     logging.debug("[*] recycle")
-    for tab in browser.list_tab():
+    for tab in browser.list_tab()[1:]:
         browser.close_tab(tab)
 
     time.sleep(1)
-    assert len(browser.list_tab()) == 0
+    assert len(browser.list_tab()) == 1
 
 
 def setup_function(function):
@@ -34,14 +34,14 @@ def test_normal_callmethod():
     tab = browser.new_tab()
 
     tab.start()
-    result = tab.Page.navigate(url="http://www.fatezero.org")
+    result = tab.Page.navigate(url="https://github.com/fate0")
     assert result['frameId']
 
     time.sleep(1)
     result = tab.Runtime.evaluate(expression="document.domain")
 
     assert result['result']['type'] == 'string'
-    assert result['result']['value'] == 'www.fatezero.org'
+    assert result['result']['value'] == 'github.com'
     tab.stop()
 
 
@@ -70,19 +70,19 @@ def test_invalid_params():
         pass
 
     try:
-        tab.Page.navigate("http://www.fatezero.org")
+        tab.Page.navigate("https://github.com/fate0")
         assert False, "never get here"
     except pychrome.CallMethodException:
         pass
 
     try:
-        tab.Page.navigate(invalid_params="http://www.fatezero.org")
+        tab.Page.navigate(invalid_params="https://github.com/fate0")
         assert False, "never get here"
     except pychrome.CallMethodException:
         pass
 
     try:
-        tab.Page.navigate(url="http://www.fatezero.org", invalid_params=123)
+        tab.Page.navigate(url="https://github.com/fate0", invalid_params=123)
     except pychrome.CallMethodException:
         assert False, "never get here"
 
@@ -169,7 +169,7 @@ def test_reuse_tab_error():
         assert False, "never get here"
 
     try:
-        tab.Page.navigate(url="http://www.fatezero.org")
+        tab.Page.navigate(url="https://github.com/fate0")
         assert False, "never get here"
     except pychrome.RuntimeException:
         pass
@@ -189,7 +189,7 @@ def test_del_event_listener():
     tab.Network.requestWillBeSent = request_will_be_sent
     tab.Network.enable()
     tab.Page.navigate(url="chrome://newtab/")
-    tab.Page.navigate(url="http://www.fatezero.org")
+    tab.Page.navigate(url="https://github.com/fate0")
 
     if tab.wait(timeout=5):
         assert False, "never get here"
@@ -282,12 +282,12 @@ def test_call_method_timeout():
     tab.Page.navigate(url="chrome://newtab/", _timeout=5)
 
     try:
-        tab.Page.navigate(url="http://www.fatezero.org", _timeout=0.8)
+        tab.Page.navigate(url="https://github.com/fate0", _timeout=0.8)
     except pychrome.TimeoutException:
         pass
 
     try:
-        tab.Page.navigate(url="http://www.fatezero.org", _timeout=0.005)
+        tab.Page.navigate(url="https://github.com/fate0", _timeout=0.005)
     except pychrome.TimeoutException:
         pass
 


### PR DESCRIPTION
Updated tests and examples (Closing the last tab in modern Chromium also closes the browser.).
Removed usage of deprecated setRequestInterceptionEnabled in examples.
Fixed tab.py to handle empty or incorrect JSON (empty or incorrect JSON triggers an exception in the threading library, leading to a high number of warnings in tests; after this fix, the number of warnings in tests decreases from 15 to 2)