### PR TITLE
Implement Get Current Tab

### DIFF
--- a/pychrome/browser.py
+++ b/pychrome/browser.py
@@ -51,6 +51,15 @@ class Browser(object):
         rp = requests.get("%s/json/activate/%s" % (self.dev_url, tab_id), timeout=timeout)
         return rp.text
 
+    def get_current_tab(self, timeout=None):
+        rp = requests.get("%s/json/activate" % self.dev_url, timeout=timeout)
+        activated_tab_id = rp.json().get('id')
+
+        if activated_tab_id in self._tabs:
+            return self._tabs[activated_tab_id]
+        else:
+            return None
+
     def close_tab(self, tab_id, timeout=None):
         if isinstance(tab_id, Tab):
             tab_id = tab_id.id

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -57,6 +57,26 @@ def test_browser_activate_tab():
     for tab in tabs:
         browser.activate_tab(tab)
 
+def test_browser_get_current_tab():
+    browser = pychrome.Browser()
+    tab1 = browser.new_tab()
+    tab2 = browser.new_tab()
+
+    browser.activate_tab(tab1)
+    current_tab = browser.get_current_tab()
+    assert current_tab == tab1
+
+    browser.activate_tab(tab2)
+    current_tab = browser.get_current_tab()
+    assert current_tab == tab2
+
+    browser.close_tab(tab2)
+    current_tab = browser.get_current_tab()
+    assert current_tab == tab1
+
+    browser.close_tab(tab1)
+    current_tab = browser.get_current_tab()
+    assert current_tab is None
 
 def test_browser_tabs_map():
     browser = pychrome.Browser()


### PR DESCRIPTION
The problem arises because the automation framework is unable to detect the transition to the new page, resulting in subsequent methods failing due to the automation still referencing elements from the previous page, as the document context has not updated to the new tab. This issue typically occurs when the automation tool fails to synchronize with the browser's tab switching mechanism, causing a disconnect between the expected page state and the actual page state within the automation workflow.

And there's no mechanism to get the current_tab. So I added a fix here `self._tabs[activated_tab_id]` this can used as an alternative method but it's still more competent if we have a built-in method for getting the current_tab